### PR TITLE
Create initial chatbot session on load

### DIFF
--- a/chatbot/static/chatbot/js/chat.js
+++ b/chatbot/static/chatbot/js/chat.js
@@ -11,6 +11,11 @@
     fetch('/chat/sessions/')
       .then(function (r) { return r.json(); })
       .then(function (sessions) {
+        if (!sessions.length) {
+          createNewSession();
+          return;
+        }
+
         var list = document.getElementById('session-list');
         list.innerHTML = '';
         sessions.forEach(function (s) {
@@ -58,13 +63,15 @@
   function createNewSession() {
     var formData = new FormData();
     formData.append('title', 'New Chat');
-    fetch('/chat/session/new/', {
+    return fetch('/chat/session/new/', {
       method: 'POST',
       headers: { 'X-CSRFToken': getCookie('csrftoken') },
       body: formData,
     }).then(function (r) { return r.json(); }).then(function (session) {
-      loadSessions();
+      var list = document.getElementById('session-list');
+      list.insertBefore(createSessionItem(session), list.firstChild);
       selectSession(session.pk);
+      return session;
     });
   }
 


### PR DESCRIPTION
## Summary
- automatically create a New Chat when the chatbot loads with no existing sessions
- insert and select the created session immediately so the first message can be sent without an extra click

## Verification
- source venv/bin/activate && python manage.py check